### PR TITLE
Per-server config

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,10 +14,7 @@ hook_table = dict()
 hook_table["edit"] = list()
 hook_table["delete"] = list()
 
-import modules.util, modules.dice, modules.roles, modules.nostalgia, modules.server_config
-
-if settings["use_logging"]:
-    import modules.logging
+import modules.util, modules.dice, modules.roles, modules.nostalgia, modules.server_config, modules.logging
 
 modules.util.setup_command_table(command_table)
 modules.dice.setup_command_table(command_table)
@@ -25,8 +22,7 @@ modules.roles.setup_command_table(command_table)
 modules.nostalgia.setup_command_table(command_table)
 modules.server_config.setup_command_table(command_table)
 
-if settings["use_logging"]:
-    modules.logging.setup_hooks(hook_table)
+modules.logging.setup_hooks(hook_table)
 
 client = discord.Client()
 

--- a/bot.py
+++ b/bot.py
@@ -24,6 +24,7 @@ modules.nostalgia.setup_command_table(command_table)
 modules.server_config.setup_command_table(command_table)
 
 modules.logging.setup_hooks(hook_table)
+modules.server_config.setup_hooks(hook_table)
 
 client = discord.Client()
 

--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ command_table = dict()
 hook_table = dict()
 hook_table["edit"] = list()
 hook_table["delete"] = list()
+hook_table["message"] = list()
 
 import modules.util, modules.dice, modules.roles, modules.nostalgia, modules.server_config, modules.logging
 
@@ -46,6 +47,10 @@ async def on_ready():
 async def on_message(message):
     # Check everything against our command table.
     # The modules specify what commands they run - so we just loop through and check
+
+    # Run through all the hooks, these get called every message:
+    for hook in hook_table["message"]:
+        await hook(client, message)
     
     for command in command_table:
         if re.search("^{}".format(command), message.content):

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,7 @@ hook_table = dict()
 hook_table["edit"] = list()
 hook_table["delete"] = list()
 
-import modules.util, modules.dice, modules.roles, modules.nostalgia
+import modules.util, modules.dice, modules.roles, modules.nostalgia, modules.server_config
 
 if settings["use_logging"]:
     import modules.logging
@@ -23,6 +23,7 @@ modules.util.setup_command_table(command_table)
 modules.dice.setup_command_table(command_table)
 modules.roles.setup_command_table(command_table)
 modules.nostalgia.setup_command_table(command_table)
+modules.server_config.setup_command_table(command_table)
 
 if settings["use_logging"]:
     modules.logging.setup_hooks(hook_table)

--- a/modules/logging.py
+++ b/modules/logging.py
@@ -2,22 +2,29 @@
 # Logs various user activities like message edits and deletions.
 import discord.utils, asyncio, os, json
 
-# Load the settings
-f = open("{}/{}".format(os.path.dirname(os.path.realpath(__file__)), "../settings.json"))
-settings = json.load(f)
-f.close()
+settings = dict()
 
-log_channel = settings["log_channel"]
+def load_settings():
+    global settings
+    # Load the settings
+    f = open("{}/{}".format(os.path.dirname(os.path.realpath(__file__)), "../settings.json"))
+    settings = json.load(f)
+    f.close()
 
 async def log_message_edit(client, old, new):
-    if not old.content == new.content:
-        await client.send_message(discord.utils.get(old.server.channels, name=log_channel, type=discord.ChannelType.text), "{}\nUser {} edited their message in {}:\nOld: {}\nNew: {}".format(new.edited_timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"), str(old.author), str(old.channel), old.content, new.content))
+    load_settings()
+    if settings[old.server.id]["use_logging"] == True:
+        log_channel = settings[old.server.id]["log_channel"]
+        if not old.content == new.content:
+            await client.send_message(discord.utils.get(old.server.channels, name=log_channel, type=discord.ChannelType.text), "{}\nUser {} edited their message in {}:\nOld: {}\nNew: {}".format(new.edited_timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"), str(old.author), str(old.channel), old.content, new.content))
 
 async def log_message_delete(client, message):
-    await client.send_message(discord.utils.get(message.server.channels, name=log_channel, type=discord.ChannelType.text), "{}\nMessage by {} was deleted in {}:\n{}\n".format(message.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"), str(message.author), str(message.channel), message.content))
+    load_settings()
+    if settings[message.server.id]["use_logging"] == True:
+        log_channel = settings[message.server.id]["log_channel"]
+        await client.send_message(discord.utils.get(message.server.channels, name=log_channel, type=discord.ChannelType.text), "{}\nMessage by {} was deleted in {}:\n{}\n".format(message.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"), str(message.author), str(message.channel), message.content))
 
 # Now setup
 def setup_hooks(hooktable):
-	if settings["use_logging"]:
-	    hooktable["edit"].append(log_message_edit)
-	    hooktable["delete"].append(log_message_delete)
+    hooktable["edit"].append(log_message_edit)
+    hooktable["delete"].append(log_message_delete)

--- a/modules/logging.py
+++ b/modules/logging.py
@@ -2,16 +2,18 @@
 # Logs various user activities like message edits and deletions.
 import discord.utils, asyncio, os, json
 
+# We create a settings dict because otherwise it complains it hasn't been initialized.
 settings = dict()
 
 def load_settings():
+    # Load the settings.
     global settings
-    # Load the settings
     f = open("{}/{}".format(os.path.dirname(os.path.realpath(__file__)), "../settings.json"))
     settings = json.load(f)
     f.close()
 
 async def log_message_edit(client, old, new):
+    # Log message edits.
     load_settings()
     if settings[old.server.id]["use_logging"] == True:
         log_channel = settings[old.server.id]["log_channel"]
@@ -19,6 +21,7 @@ async def log_message_edit(client, old, new):
             await client.send_message(discord.utils.get(old.server.channels, name=log_channel, type=discord.ChannelType.text), "{}\nUser {} edited their message in {}:\nOld: {}\nNew: {}".format(new.edited_timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"), str(old.author), str(old.channel), old.content, new.content))
 
 async def log_message_delete(client, message):
+    # Log message deletions.
     load_settings()
     if settings[message.server.id]["use_logging"] == True:
         log_channel = settings[message.server.id]["log_channel"]

--- a/modules/roles.py
+++ b/modules/roles.py
@@ -1,11 +1,24 @@
 # roles.py
 # Role management, such as assigning and removing roles.
-import discord.utils, re
+import discord.utils, re, os, json
 
 # TODO: Set up config for role list
 allowed_roles = []
 
+# We create a settings dict because otherwise it complains it hasn't been initialized.
+settings = dict()
+
+def load_settings():
+    # Load the settings.
+    global settings
+    f = open("{}/{}".format(os.path.dirname(os.path.realpath(__file__)), "../settings.json"))
+    settings = json.load(f)
+    f.close()
+
 async def give_role(message, client):
+    load_settings()
+    # Grab the list of roles - they're just plaintext names
+    allowed_roles = settings[message.server.id]["allowed_roles"]
     role_list = ""
     for role in allowed_roles:
         role_list += "{}, ".format(role)
@@ -33,13 +46,19 @@ async def give_role(message, client):
             await client.send_message(message.channel, ":no_entry: That role is in the allowed roles list, but does not actually exist.\nPlease notify the bot admin.")
 
 async def list_roles(message, client):
+    load_settings()
+    # Grab the list of roles - they're just plaintext names
+    allowed_roles = settings[message.server.id]["allowed_roles"]
     roleList = ""
     for role in allowed_roles:
-        roleList += "{}, ".format(i)
+        roleList += "{}, ".format(role)
     roleList = roleList[:-2]
     await client.send_message(message.channel, "You can assign yourself any of the following:\n{}".format(roleList))
 
 async def remove_role(message, client):
+    load_settings()
+    # Grab the list of roles - they're just plaintext names
+    allowed_roles = settings[message.server.id]["allowed_roles"]
     role_list = ""
     for role in allowed_roles:
         role_list += "{}, ".format(role)

--- a/modules/server_config.py
+++ b/modules/server_config.py
@@ -2,29 +2,33 @@
 # Allows admins of a server to configure the bot.
 import discord, asyncio, json, os
 
+# This should be hardcoded - that way it's the same across all servers.
+# Might change in the future if necessary.
 admin_role_name = "EfficientEnigma Admin"
 
 settings = dict()
 
 def load_settings():
-    # Load the settings
+    # Load the settings.
     global settings
     f = open("{}/{}".format(os.path.dirname(os.path.realpath(__file__)), "../settings.json"), 'r')
     settings = json.load(f)
     f.close()
 
 def save_settings(in_settings):
-    # Save the settings
+    # Save the settings.
     f = open("{}/{}".format(os.path.dirname(os.path.realpath(__file__)), "../settings.json"), 'w')
     json.dump(in_settings, f)
     f.close()
 
 def server_has_settings(in_settings, message):
+    # Check if the server has settings - if not, just create a new table for them.
     if not message.server.id in in_settings:
         in_settings[message.server.id] = dict()
     return in_settings
 
 async def check_if_can_edit(user, message, client):
+    # Does this user have permission to change admin stuff?
     found_admin = False
     for r in message.server.roles:
         if r.name == admin_role_name:
@@ -38,12 +42,13 @@ async def check_if_can_edit(user, message, client):
     return result
 
 async def check_and_return(message, client):
+    # DEBUG/TEST COMMAND - Checks if a user can edit, and tells them.
     result = await check_if_can_edit(message.author, message, client)
     await client.send_message(message.channel, "{} Have role for editing: {}".format(message.author.mention, result))
 
 async def toggle_logs(message, client):
-    global settings
     # Toggles logs, simple as that.
+    global settings
     load_settings()
     settings = server_has_settings(settings, message)
     if not "use_logging" in settings[message.server.id]:

--- a/modules/server_config.py
+++ b/modules/server_config.py
@@ -1,0 +1,15 @@
+# settings.py
+# Allows admins of a server to configure the bot.
+import discord, asyncio
+
+async def check_if_can_edit(user, message, client):
+    result = discord.utils.get(message.server.roles, name="EfficientEnigma Admin") in user_roles
+    return result
+
+async def check_and_return(message, client):
+    result = await check_if_can_edit(message.author, message, client)
+    await client.send_message(message.channel, "{} Have role for editing: {}".format(message.author.mention, result))
+
+# Add the commands to the global command table.
+def setup_command_table(table):
+    table["\\$check"] = check_and_return

--- a/modules/server_config.py
+++ b/modules/server_config.py
@@ -2,8 +2,19 @@
 # Allows admins of a server to configure the bot.
 import discord, asyncio
 
+admin_role_name = "EfficientEnigma Admin"
+
 async def check_if_can_edit(user, message, client):
-    result = discord.utils.get(message.server.roles, name="EfficientEnigma Admin") in user_roles
+    found_admin = False
+    for r in message.server.roles:
+        if r.name == admin_role_name:
+            found_admin = True
+
+    if not found_admin:
+         await client.send_message(message.channel, "{} It looks like the admin role *doesn't exist* - if you are not able to add one, please tell the server manager to add a role named \"{}\" and assign it to whoever needs it.".format(message.author.mention, admin_role_name))
+         return False
+
+    result = discord.utils.get(message.server.roles, name=admin_role_name) in user.roles
     return result
 
 async def check_and_return(message, client):

--- a/modules/server_config.py
+++ b/modules/server_config.py
@@ -129,6 +129,18 @@ async def remove_role(message, client):
     else:
         await client.send_message(message.channel, "{} Sorry, you don't have permission to edit settings.".format(message.author.mention))
 
+async def set_up_defaults(client, message):
+    global settings
+    load_settings()
+    if not message.server.id in settings:
+        print("Had to set up default settings for server {}".format(message.server.id))
+        settings[message.server.id] = dict()
+        settings[message.server.id]["allowed_roles"] = []
+        settings[message.server.id]["use_logging"] = True
+        settings[message.server.id]["log_channel"] = "modlog"
+        save_settings(settings)
+
+
 # Add the commands to the global command table.
 def setup_command_table(table):
     table["\\$check"] = check_and_return
@@ -136,3 +148,6 @@ def setup_command_table(table):
     table["\\$logchannel"] = set_log_channel
     table["\\$allowrole"] = allow_role
     table["\\$removerole"] = remove_role
+
+def setup_hooks(hooktable):
+    hooktable["message"].append(set_up_defaults)


### PR DESCRIPTION
This allows server admins to set their own settings per-server from within Discord.

To-do (required):

- [x] Add checks to see if a user has the role
- [x] Change logging on/off
- [x] Change logging channel
- [x] Allow/disallow users to assign roles 
- [x] Set default values

To-do (optional but nice):

- [ ] Set on/off manually and not just a toggle
- [ ] Change features (like !nostalgia and !roll) on and off
- [ ] Properly rewrite !help (not necessary for this but would be nice to prevent confusion with the new commands, see #17)